### PR TITLE
add trailing comma to prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "jsxBracketSameLine": true,
   "printWidth": 80,
   "semi": true,
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "all"
 }


### PR DESCRIPTION
- This fixes the removal of trailing comments on save, but I haven't yet found a way to prevent vscode making multi-line arrays into single line. 
- https://github.com/prettier/prettier-vscode/issues/352